### PR TITLE
chore(shape_generator): v0.0.2 - relax analyzer dependency (v5.0.0 and up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### 0.0.2 - 2023-08-11 (`shape_generator` only)
+
+- chore(shape_generator): relax dependency constraint on `analyzer` to maximize compatibility with Flutter projects ([#10](https://github.com/Betterment/shape/pull/10))
+
 ### 0.0.1 - 2023-08-02
 
 - feat: add `shape`, `shape_generator` and `shape_starter_kit` packages (with example project)

--- a/packages/shape_generator/pubspec.yaml
+++ b/packages/shape_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shape_generator
 description: The code generator for the shape package. For more information,
   check out the README of the shape package.
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/betterment/shape/tree/main/packages/shape_generator
 
 environment:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Breaking Changes

NO

## Description

This PR relaxes the dependency in `shape_generator` on `analyzer` to be compatible with v`5.12.0` and up (including v`6.x.x`).

The dependency was previously set to accept any version from `6.0.0` and above, but the current build of Flutter has a transient dependency on `5.12.0`, meaning `shape_generator` cannot be used in any package that uses Flutter, its testing libraries, and/or some versions of `package:test`.

It also contains a version bump from `0.0.1` to `0.0.2`.

@btrautmann We need to publish a new release right after this has been merged.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
